### PR TITLE
Merchant coupon deactivate

### DIFF
--- a/app/controllers/coupons_controller.rb
+++ b/app/controllers/coupons_controller.rb
@@ -5,8 +5,7 @@ class CouponsController < ApplicationController
   end
 
   def show
-   
-    @coupon = Coupon.find(params[:id])    
+    @coupon = Coupon.find(params[:id])
   end
 
   def new
@@ -27,10 +26,21 @@ class CouponsController < ApplicationController
       redirect_to new_merchant_coupon_path(merchant)
     end
   end
+
+  def update
+    coupon = Coupon.find(params[:id])
+    merchant = Merchant.find(params[:merchant_id])
+    coupon.update(coupon_status_params)
+    redirect_to merchant_coupon_path(merchant, coupon)
+  end
 end
 
 private
 
 def coupon_params
   params.permit(:coupon_name, :coupon_code, :discount_amount, :discount_type, :status)
+end
+
+def coupon_status_params
+  params.permit(:status)
 end

--- a/app/views/coupons/show.html.erb
+++ b/app/views/coupons/show.html.erb
@@ -7,3 +7,14 @@
 <%= @coupon.status %>
 
 <p>count: <%= @coupon.transaction_success_count %>
+
+<section id="activated">
+  <% if @coupon.status == "activated" %>
+    <%= form_with url: merchant_coupon_path(@coupon.merchant.id, @coupon), method: :patch do |form|  %>
+      <div>
+        <%= form.hidden_field :status, value: "deactivated" %>
+        <%= form.submit "deactivate" %>
+      </div>
+    <% end %>
+  <% end %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :coupons, only: [:index, :show, :new]
+    resources :coupons, only: [:index, :show, :new, :update]
     post 'coupons', to: 'coupons#create'
   end
 

--- a/spec/features/merchants/coupons/show_spec.rb
+++ b/spec/features/merchants/coupons/show_spec.rb
@@ -109,7 +109,6 @@ RSpec.describe "Merchant Coupons Show Page" do
         expect(@active_coupon1.status).to eq("activated")
         click_button("deactivate")
         @active_coupon1.reload
-        save_and_open_page
         expect(current_path).to eq(merchant_coupon_path(@merchant1, @active_coupon1))
         expect(@active_coupon1.status).to eq("deactivated")
       end

--- a/spec/features/merchants/coupons/show_spec.rb
+++ b/spec/features/merchants/coupons/show_spec.rb
@@ -75,9 +75,44 @@ RSpec.describe "Merchant Coupons Show Page" do
 
     it "displays the count of how many times the coupon has been used in a transaction" do
       visit merchant_coupon_path(@merchant1, @active_coupon1)
-      save_and_open_page
       expect(page).to have_content(@active_coupon1.transaction_success_count)
       expect(page).to have_content("count: 1")
+    end
+
+                #us 4 4. Merchant Coupon Deactivate
+
+            # As a merchant 
+            # When I visit one of my active coupon's show pages
+            # I see a button to deactivate that coupon
+            # When I click that button
+            # I'm taken back to the coupon show page 
+            # And I can see that its status is now listed as 'inactive'.
+
+            # * Sad Paths to consider: 
+            # 1. A coupon cannot be deactivated if there are any pending invoices with that coupon.
+
+    it "displays a button to deactivate that coupon" do
+      visit merchant_coupon_path(@merchant1, @active_coupon1)
+      within "#activated" do
+        expect(page).to have_button("deactivate")
+      end
+      
+      visit merchant_coupon_path(@merchant1, @deactive_coupon2)
+      within "#activated" do
+        expect(page).to_not have_button("deactivate")
+      end
+    end
+
+    it "when button is clicked taken back to the coupon show page and see status as inactive" do
+      visit merchant_coupon_path(@merchant1, @active_coupon1)
+      within "#activated" do
+        expect(@active_coupon1.status).to eq("activated")
+        click_button("deactivate")
+        @active_coupon1.reload
+        save_and_open_page
+        expect(current_path).to eq(merchant_coupon_path(@merchant1, @active_coupon1))
+        expect(@active_coupon1.status).to eq("deactivated")
+      end
     end
   end
 end

--- a/spec/features/merchants/coupons/show_spec.rb
+++ b/spec/features/merchants/coupons/show_spec.rb
@@ -74,9 +74,10 @@ RSpec.describe "Merchant Coupons Show Page" do
     end
 
     it "displays the count of how many times the coupon has been used in a transaction" do
-      visit merchant_coupon
+      visit merchant_coupon_path(@merchant1, @active_coupon1)
+      save_and_open_page
       expect(page).to have_content(@active_coupon1.transaction_success_count)
-      expect(page).to have_content(1)
+      expect(page).to have_content("count: 1")
     end
   end
 end


### PR DESCRIPTION
Adds all of User Story 4.  Adds button to deactivate for all merchants coupons show pages where status is already active.  When button is clicked the status updates on the page to deactivated.  